### PR TITLE
Fix Date.parse error on Chromium

### DIFF
--- a/js/solari.js
+++ b/js/solari.js
@@ -364,7 +364,7 @@ function updateSolariBoard() {
         }
         var next_due_row = solariData[i];
         time = next_due_row.sTime;
-        var timeDelta = Date.parse(next_due_row.sDate + " " + time).getTime() - new Date().getTime();
+        var timeDelta = Date.parse(next_due_row.sDate + ", " + time).getTime() - new Date().getTime();
         var nOffset = timeDelta > 0 ? Math.floor(timeDelta / (1000 * 60 * 60 * 24)) : Math.ceil(timeDelta / (1000 * 60 * 60 * 24)); //divide by miliseconds per day and round to zero
         var offset = (nOffset === 0 ? "" : nOffset.toString() + "d"); //hide if next due is today
         if(status_override) {


### PR DESCRIPTION
On Chromium the Javascript Date.parse functions appears to need a comma
between date and time.

Example:
Date.parse("today 13:00") won't parse
Date.parse("today, 13:00") works
