### PR TITLE
Handle URLs missing the ? and recover from a fail

### DIFF
--- a/js/solari.js
+++ b/js/solari.js
@@ -301,9 +301,6 @@ function SpinIt(selector, num_spins, rate, pixel_distance, final_pos) {
 }
 
 function GetFailBoard() {
-
-    $("#arrivals .solari-board-header, #arrivals .solari-board-columns").hide(1000);
-
     var fail_whale = [];
     fail_whale[0] = "    v  v        v";
     fail_whale[1] = "    !  !  v     !  v";


### PR DESCRIPTION
For /example/index.html to work right out of the box, the URL in solari.js line 53 needs to be "../example/postJsonp.py?” with a trailing ? (or else the posts go to postJsonp.pycallback=*\* and error)  But instead of editing that line, I wanted to make the ? optional so a variety of url formats will work.

While in there I made some edits that seemed of value, see commit comments for explanations.
