### PR TITLE
Add an example board that is tied to a Fogbugz URL Trigger

### DIFF
--- a/example_realtime/fbsettings.py
+++ b/example_realtime/fbsettings.py
@@ -1,0 +1,4 @@
+# To use this example with your own FogBugz installation, fill in
+# the following values as appropriate
+URL = "https://(example).fogbugz.com/"
+TOKEN = "(See https://help.fogcreek.com/8447/how-to-get-a-fogbugz-xml-api-token)"

--- a/example_realtime/index.html
+++ b/example_realtime/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Solari Board Realtime Example</title>
+
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css?family=Kelly+Slab" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Yanone+Kaffeesatz" rel="stylesheet" type="text/css">
+
+    <!-- jQuery, transit (for animations), date.js and the solari board -->
+    <script type="text/javascript" src="../js/jquery.min.js"></script>
+    <script type="text/javascript" src="../js/jquery.transit.min.js"></script>
+    <script type="text/javascript" src="../js/date.js"></script>
+    <script type="text/javascript" src="../js/solari.js"></script>
+
+    <!-- CSS -->
+    <link rel="stylesheet" type="text/css" href="../css/solari.css" />
+
+    <!-- Audio -->
+    <audio src="../audio/solari.mp3" id="solari-audio">
+        Your browser does not support the audio element.
+    </audio>
+    <script>
+        $(document).ready(function() {
+            URL = "liveFogbugz.py";
+            REFRESH_TIME = 30;
+            addSolariBoard();
+        });
+    </script>
+    <script src="/cgi-bin/example_realtime/refreshFogbugz.py">
+        // This forces one refresh on page load to start with the latest data
+        // 
+        // A trigger must be configured in FogBugz to handle live updates
+        //   1) In the Settings menu (the gear icon), select URL Trigger
+        //   2) Select the Case Event types that should trigger an update to the Solari board
+        //   3) In URL, enter the web address to refreshFogbugz.py
+        //   4) Optional, define a Filter for only cases that apply to the Solari board
+    </script>
+</head>
+</html>

--- a/example_realtime/liveFogbugz.py
+++ b/example_realtime/liveFogbugz.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+from __future__ import print_function
+
+import sys, os
+import cgi
+import time
+
+def cgi_callback():
+    params = cgi.parse_qs(os.environ['QUERY_STRING'])
+
+    # lastts is the last modified date that this browser has already loaded, 0 means this is an initial request
+    lastts = 0
+    if params.has_key('ts'):
+        lastts = int(params['ts'][0])
+    # keep count of the number of times waiting so this takes no longer than 30 sec to respond
+    attempt = 0
+
+    ts = ''
+    while ts == '':
+        attempt += 1
+        try:
+            stats = os.stat('fogbugz.json')
+            if (attempt > 56 or int(stats.st_mtime) > lastts):
+                # the file either has new data, or we've been waiting long enough, exit the loop
+                ts = int(stats.st_mtime)
+            else:
+                # the file has no new data, wait a half a second and try again
+                time.sleep(0.5)
+        except:
+            break
+
+    if ts == "":
+        # a file was not found, return invalid JSON to raise an error in the UI
+        json = 'Show fail whale because refreshFogBugz.py has never been called'
+        ts = 0
+    else:
+        f = open('fogbugz.json')
+        json = f.read()
+        f.close()
+        if json == '':
+            json = '[]'
+    
+    print('Content-Type: application/javascript\n')
+    # remember this last modified ts, so future requests can tell if there's new data
+    print('URL_SUFFIX = "&ts=%s";' % (ts))
+
+    # if responding immediately then kick off another read
+    if attempt == 1 and not params.has_key('ts'):
+        print('setTimeout(updateSolariBoard, 1000);')
+
+    # support a callback param, or default to "void"
+    callback = 'void'
+    if params.has_key('callback'):
+        callback = params['callback'][0]
+
+    # send the json to jQuery's callback
+    print('%s(%s);' % (callback,json))
+
+
+if __name__ == '__main__':
+    cgi_callback()

--- a/example_realtime/refreshFogbugz.py
+++ b/example_realtime/refreshFogbugz.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: UTF-8 -*-
+
+from __future__ import print_function
+
+import json
+import random
+import sys, os
+import cgi
+from datetime import datetime
+
+import fbsettings
+from fogbugz import FogBugz
+
+
+def cgi_callback():
+    ## Begin sample data loading ##
+    ## Customize with your own logic ##
+    fb = FogBugz(fbsettings.URL, fbsettings.TOKEN)
+    resp = fb.search(q='project:inbox area:* status:active due:today orderby:due',
+                     cols="dtDue,sTitle")
+
+    cases = []
+    for case in resp.cases:
+        date = datetime.strptime(case.dtdue.string, '%Y-%m-%dT%H:%M:%SZ').strftime('%m/%d/%Y')
+        time = case.dtdue.string[11:16]
+        departure = case.stitle.string.encode('UTF-8').replace('\"', '')
+        track = random.randrange(0, 100)
+        if (datetime.strptime(case.dtdue.string, '%Y-%m-%dT%H:%M:%SZ') - datetime.now()).days < 0:
+           status = 3
+        else:
+           status = 2
+        cases.append({'sDate': date,
+                      'sTime': time,
+                      'sDeparture': departure,
+                      'nStatus': status,
+                      'nTrack': track,
+                      'bLight': False})
+
+    # turn on the top light
+    try:
+        cases[0]['bLight'] = True
+    except:
+        pass
+
+    ## End sample data loading ##
+
+    # save json data to be read by liveFogbugz.py
+    f = open('fogbugz.json','w')
+    f.write(json.dumps(cases, sys.stdout))
+    f.close()
+
+    # this page doesn't return the json, but might as well return some stats
+    stats = {'error': False, 'cases': len(cases)}
+
+    # support a callback param, or default to "void"
+    params = cgi.parse_qs(os.environ['QUERY_STRING'])
+    callback = 'void'
+    if params.has_key('callback'):
+        callback = params['callback'][0]
+
+    print('Content-Type: application/javascript\n')
+    print('%s(%s);' % (callback,json.dumps(stats, sys.stdout)))
+
+
+if __name__ == '__main__':
+    cgi_callback()

--- a/js/solari.js
+++ b/js/solari.js
@@ -52,6 +52,9 @@ var EMPTY_ROW = {
 var status_override = true;
 var URL = "../example/postJsonp.py"
 
+//used to add extra params that change over time.  /example_realtime makes use of this
+var URL_SUFFIX = "";
+
 var Status = {
     "none": 0,
     "all_aboard": 1,
@@ -336,7 +339,7 @@ function updateSolariBoard() {
         return;
     }
     syncing = true;
-    $.getJSON(URL + (URL.indexOf("?") === -1 ? '?' : '&') + "callback=?", function(new_board) {
+    $.getJSON(URL + (URL.indexOf("?") === -1 ? '?' : '&') + "callback=?" + URL_SUFFIX, function(new_board) {
             syncing = false;
             if (new_board === null) {
                 //the last updated footer won't get refreshed, but if data is null, it probably shouldn't


### PR DESCRIPTION
Starting with the postFogbugz.py sample, I added a new sample folder implementing push technology for a live, event-driven sync with a Fogbugz account.

/example_realtime/liveFogbugz.py implements a long-pull method used in web-based stock tickers to show live prices.  It supports multiple simultaneous clients, but if you plan to have a few hundred or more, you'll need a modern web server designed to handle idle web sockets.

/example_realtime/refreshFogbugz.py is what triggers a push of new data to all browsers with the Solari Board open.

/example_realtime/index.html contains instructions for setting up the URL trigger in a company’s Fogbugz account.

Also, this example shows how URL and REFRESH_TIME can be customized from index.html without needing to modify solari.js
